### PR TITLE
 UPSTREAM: <carry>: Set CSI migration off when a test needs it

### DIFF
--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -440,6 +440,11 @@ func volumeAttachmentRecoveryTestCase(t *testing.T, tc vaTest) {
 	} else {
 		plugins = controllervolumetesting.CreateTestPlugin()
 	}
+
+	// OCP Carry: disable ADCCSIMigrationGCEPD feature in this unit test when necessary.
+	// OCP forces CSI migration in ADC "on", this unit test may need it "off".
+	defer featuregatetesting.SetFeatureGateDuringTest(t, utilfeature.DefaultFeatureGate, features.ADCCSIMigrationGCEPD, tc.csiMigration)()
+
 	nodeInformer := informerFactory.Core().V1().Nodes().Informer()
 	podInformer := informerFactory.Core().V1().Pods().Informer()
 	pvInformer := informerFactory.Core().V1().PersistentVolumes().Informer()

--- a/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
+++ b/pkg/controller/volume/attachdetach/attach_detach_controller_test.go
@@ -365,7 +365,6 @@ type vaTest struct {
 }
 
 func Test_ADC_VolumeAttachmentRecovery(t *testing.T) {
-	t.Skip("sig-storage to debug Test_ADC_VolumeAttachmentRecovery")
 	for _, tc := range []vaTest{
 		{ // pod is scheduled
 			testName:          "Scheduled pod",


### PR DESCRIPTION
In OCP we carry a patch that forces CSI migration to be enabled in Attach/Detach controller (ADC). Update ADC unit tests to disable the migration there when an unit test needs it disabled.

Also revert "UPSTREAM: <carry> disable Test_ADC_VolumeAttachmentRecovery unit", 015f4df.